### PR TITLE
add autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,4 @@
+SUBDIRS = src
+dist_doc_DATA = README.md LICENSE
+ACLOCAL_AMFLAGS = -I m4
+

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,13 @@
+AC_INIT([oas], [1.0], [mh+debian-packages@zugschlus.de])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AC_PROG_CC
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_FILES([
+ Makefile
+ src/Makefile
+])
+AC_OUTPUT
+AC_CONFIG_MACRO_DIR([m4])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+LT_INIT
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,0 +1,9 @@
+lib_LTLIBRARIES = liboas.la
+liboas_la_SOURCES = oas.c connect.c
+
+#SOURCES = oas.c connect.c
+
+#liboas.so: oas.c connect.c
+#	shell echo $(CC)
+#	$(CC) connect.c oas.c  -ldl $(INCLUDES) $(CFLAGS) $(CPPFLAGS)
+


### PR DESCRIPTION
add simple (and probably badly understood) Makefile.am and configure.ac files to allow simpler build of Debian package with debhelper.